### PR TITLE
Adding in redirect to project#show for new project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.0.2"
+ruby "3.0.6"
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -411,7 +412,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 3.0.2p107
+   ruby 3.0.6p216
 
 BUNDLED WITH
    2.3.23

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,7 +31,7 @@ class ProjectsController < ApplicationController
     @project = Project.new(projects_params)
     if @project.save
       flash[:success] = "Project created!"
-      redirect_to "/projects"
+      redirect_to project_path(@project)
     else
       flash.now[:error] = @project.errors.full_messages
       render :new

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ProjectsController, type: :controller do
       it "redirects to the projects" do
         post :create, params: {project: valid_params}
 
-        expect(response).to redirect_to "/projects"
+        expect(response).to redirect_to project_path(Project.last)
       end
     end
 

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "managing projects", js: true do
       fill_in "project[title]", with: "Super Sub Project"
       click_button "Create"
       expect(page).to have_content "Project created!"
-      expect(current_path).to eq projects_path
+      expect(current_path).to eq project_path(Project.last)
     end
 
     it "lists available sub projects with a link" do


### PR DESCRIPTION
### Jira Ticket

https://github.com/orgs/fastruby/projects/49/views/1?pane=issue&itemId=114824202

### Motivation / Context

Feature description
As a user
After I create a project
I want to be taken to the show page for that project
Current behavior
Users are taken to the projects index page.

Acceptance criteria
The app behaves like the steps in the description
The new feature is covered by tests

### QA / Testing Instructions

1) Create new project
2) Confirm it redirects to the project#show page vs. index

### Screenshots:

