### PR TITLE
Add in redirect to parent project when creating sub-project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,7 +31,11 @@ class ProjectsController < ApplicationController
     @project = Project.new(projects_params)
     if @project.save
       flash[:success] = "Project created!"
-      redirect_to project_path(@project)
+      if @project.parent_id.present?
+        redirect_to project_path(@project.parent)
+      else
+        redirect_to project_path(@project)
+      end
     else
       flash.now[:error] = @project.errors.full_messages
       render :new

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "managing projects", js: true do
       fill_in "project[title]", with: "Super Sub Project"
       click_button "Create"
       expect(page).to have_content "Project created!"
-      expect(current_path).to eq project_path(Project.last)
+      expect(current_path).to eq project_path(project.id)
     end
 
     it "lists available sub projects with a link" do


### PR DESCRIPTION
### Jira Ticket

https://github.com/orgs/fastruby/projects/49/views/1?pane=issue&itemId=114824203

### Motivation / Context

Feature description
As a user
After I create a sub-project
I want to be taken to the show page of the parent project
Current behavior
Users are taken to the projects index page.

Acceptance criteria
The app behaves like the steps in the description
The new feature is covered by tests

### QA / Testing Instructions

1) Add New Project
2) Add a subproject
3) confirm it redirects to the parent project vs. the sub-project.

### Screenshots:
