### PR TITLE
Fix bug in button label getting removed in form validation error

### DIFF
--- a/app/views/estimates/create.js.erb
+++ b/app/views/estimates/create.js.erb
@@ -6,6 +6,7 @@
     addEstimate.remove()
     closeModal()
   <% else %>
+    <% provide(:button_text, 'Create') %>
     updateModal("New estimate", "<%= j(render partial: 'modal_body') %>")
   <% end %>
 })()

--- a/app/views/estimates/update.js.erb
+++ b/app/views/estimates/update.js.erb
@@ -2,5 +2,6 @@
   <%= render partial: 'update_estimates', locals: {estimate: @estimate} %>
   closeModal()
 <% else %>
+  <% provide(:button_text, 'Save Changes') %>
   updateModal("Edit estimate", "<%= j(render partial: 'modal_body') %>")
 <% end %>


### PR DESCRIPTION
### Jira Ticket

https://github.com/orgs/fastruby/projects/49/views/1?pane=issue&itemId=114824211

### Motivation / Context

Problem
When creating/editing an estimation, if the form is invalid the submit button loses its label.

Steps to reproduce
Click Add Estimate for a story
Make sure that Best case estimate value is HIGHER than the Worst case estimate
Click Create
Check the attachment for a screenshot of the error

Acceptance criteria
After submitting an invalid form, the text button should be correct.

### QA / Testing Instructions

1. Go to a project.
2. add an estimate - set low end higher to high end - confirm button label is still there when form invalidates
3. edit an estimate - set low end higher to high end - confirm button label is still there when form invalidates

### Screenshots:
